### PR TITLE
Update Preorder Logic

### DIFF
--- a/scripts/pw/README.md
+++ b/scripts/pw/README.md
@@ -166,24 +166,26 @@ preorderKeys
     })
 })
 ```
-Next create a script to randomly select `Chosen` Preorder IDs. This transaction will allow for the Preorder to change its `PreorderStatus`
+Next, create a script to randomly select chosen Preorder IDs. Then create an array of chosen Preorder IDs to automatically mint the preorders to the owner of the preorders. 
 - `PreorderId`: A number ID mapped to the preorder.
-- `PreorderStatus`: A status with a value of either `Chosen` or `NotChosen`
+- `Preorders`: A Vec of chosen preorders
 ```javascript
-await api.tx.pwNftSale.setPreorderStatus(0, 'Chosen')
+const chosenPreorders = api.createType('Vec<u32>', [0, 1, 2, 4, 10, 6, 12, 11]);
+await api.tx.pwNftSale.mintChosenPreorders(chosenPreorders)
     .signAndSend(overlord);
 ```
-After assigning the preorder statuses, query for all the Preorders sorted by account.
+
+Lastly, create take the not chosen Preorder IDs and refund the account owners that reserved payment for the preorder.
+- `PreorderId`: A number ID mapped to the preorder.
+- `Preorders`: A Vec of chosen preorders
 ```javascript
-const userPreorderResults = await api.query.pwNftSale.preorderResults.entries(ferdie.address);
-userPreorderResults
-    .map(([key, value]) =>
-        [key.args[0].toString(), key.args[1].toNumber(), value.toHuman()]
-    ).forEach(([account, preorderId, preorderInfo]) => {
-    console.log({
-        account,
-        preorderId,
-        preorderInfo,
-    })
-})
+const notChosenPreorders = api.createType('Vec<u32>', [7, 3, 5, 8, 9, 13]);
+await api.tx.pwNftSale.refundNotChosenPreorders(notChosenPreorders)
+    .signAndSend(overlord);
+```
+
+## [4] Enable Last Day of Sale for unlimited purchases for all 3 levels of the remaining Origin of Shell supply.
+```javascript
+await api.tx.pwNftSale.setStatusType(true, 'LastDayOfSale')
+    .signAndSend(overlord);
 ```

--- a/scripts/pw/populate-dummy-data.js
+++ b/scripts/pw/populate-dummy-data.js
@@ -29,15 +29,11 @@ async function main() {
             OriginOfShellType: {
                 _enum: ['Prime', 'Magic', 'Legendary']
             },
-            PreorderStatus: {
-                _enum: ['Pending', 'Chosen', 'NotChosen']
-            },
             PreorderInfo: {
                 owner: "AccountId",
                 race: "RaceType",
                 career: "CareerType",
                 metadata: "BoundedString",
-                preorder_status: "PreorderStatus",
             },
             NftSaleInfo: {
                 race_count: "u32",

--- a/scripts/pw/queries.js
+++ b/scripts/pw/queries.js
@@ -30,15 +30,11 @@ async function main() {
             OriginOfShellType: {
                 _enum: ['Prime', 'Magic', 'Legendary']
             },
-            PreorderStatus: {
-                _enum: ['Pending', 'Chosen', 'NotChosen']
-            },
             PreorderInfo: {
                 owner: "AccountId",
                 race: "RaceType",
                 career: "CareerType",
                 metadata: "BoundedString",
-                preorder_status: "PreorderStatus",
             },
             NftSaleInfo: {
                 race_count: "u32",
@@ -81,11 +77,6 @@ async function main() {
     const tradeNegotiator = api.createType('CareerType', 'TradeNegotiator');
     const hackerWizard = api.createType('CareerType', 'HackerWizard');
     const web3Monk = api.createType('CareerType', 'Web3Monk');
-
-    // PreorderStatus
-    const pending = api.createType('PreorderStatus', 'Pending');
-    const chosen = api.createType('PreorderStatus', 'Chosen');
-    const notChosen = api.createType('PreorderStatus', 'NotChosen');
 
     // list spirit
     {
@@ -176,7 +167,6 @@ async function main() {
     //         race: 'Pandroid',
     //         career: 'HackerWizard',
     //         metadata: 'I am Prime',
-    //         preorderStatus: 'Chosen'
     //      }
     // }
     {

--- a/scripts/pw/transactions.js
+++ b/scripts/pw/transactions.js
@@ -29,15 +29,11 @@ async function main() {
             OriginOfShellType: {
                 _enum: ['Prime', 'Magic', 'Legendary']
             },
-            PreorderStatus: {
-                _enum: ['Pending', 'Chosen', 'NotChosen']
-            },
             PreorderInfo: {
                 owner: "AccountId",
                 race: "RaceType",
                 career: "CareerType",
                 metadata: "BoundedString",
-                preorder_status: "PreorderStatus",
             },
             NftSaleInfo: {
                 race_count: "u32",
@@ -88,10 +84,6 @@ async function main() {
     const hackerWizard = api.createType('CareerType', 'HackerWizard');
     const web3Monk = api.createType('CareerType', 'Web3Monk');
 
-    // PreorderStatus
-    const pending = api.createType('PreorderStatus', 'Pending');
-    const chosen = api.createType('PreorderStatus', 'Chosen');
-    const notChosen = api.createType('PreorderStatus', 'NotChosen');
 
     // // produce whitelist
     // {
@@ -167,24 +159,18 @@ async function main() {
             .signAndSend(ferdie);
     }
 
-    // privileged function preorder status to declare Chosen or NotChosen preorders
+    // privileged function to mint chosen preorders
     {
-        // Preorder id
-        // status ['Chosen', 'NotChosen']
-        await api.tx.pwNftSale.setPreorderStatus()
+        const chosenPreorders = api.createType('Vec<u32>', [0, 1, 2, 4, 10, 6, 12, 11]);
+        await api.tx.pwNftSale.mintChosenPreorders(chosenPreorders)
             .signAndSend(overlord);
     }
 
-    // Claim chosen preorders
+    // privileged function to refund not chosen preorders
     {
-        await api.tx.pwNftSale.claimChosenPreorders()
-            .signAndSend(user);
-    }
-
-    // Claim refund for not chosen preorders
-    {
-        await api.tx.pwNftSale.claimRefundPreorders()
-            .signAndSend(user);
+        const notChosenPreorders = api.createType('Vec<u32>', [7, 3, 5, 8, 9, 13]);
+        await api.tx.pwNftSale.refundNotChosenPreorders(notChosenPreorders)
+            .signAndSend(overlord);
     }
 
     // Update the Prime Origin of Shell NFTs based on the number of Whitelist NFTs claimed

--- a/traits/src/preorders.rs
+++ b/traits/src/preorders.rs
@@ -7,14 +7,6 @@ use sp_std::cmp::Eq;
 use crate::{career::CareerType, race::RaceType};
 use serde::{Deserialize, Serialize};
 
-#[derive(Encode, Decode, Clone, Copy, Eq, PartialEq, RuntimeDebug, TypeInfo, MaxEncodedLen)]
-#[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
-pub enum PreorderStatus {
-	Pending,
-	Chosen,
-	NotChosen,
-}
-
 #[derive(Encode, Decode, Eq, PartialEq, Clone, RuntimeDebug, TypeInfo, MaxEncodedLen)]
 #[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
 pub struct PreorderInfo<AccountId, BoundedString> {
@@ -26,6 +18,4 @@ pub struct PreorderInfo<AccountId, BoundedString> {
 	pub career: CareerType,
 	/// Metadata of the owner
 	pub metadata: BoundedString,
-	/// Preorder status
-	pub preorder_status: PreorderStatus,
 }


### PR DESCRIPTION
Remove the requirement of the users minting their chosen preorders and claiming refunds for not chosen preorders. Now whenever a preorder is chosen, the `overlord` account will also mint the Origin of Shell to the preorder owner and will automatically refund the not chosen preorders.