### PR TITLE
Refactor RMRK Core User/Internal Functions

### DIFF
--- a/pallets/rmrk-core/src/functions.rs
+++ b/pallets/rmrk-core/src/functions.rs
@@ -403,7 +403,7 @@ where
 					collection_id,
 					nft_id,
 					res.resource,
-					true,
+					false,
 					res.id,
 				)?;
 			}

--- a/pallets/rmrk-core/src/functions.rs
+++ b/pallets/rmrk-core/src/functions.rs
@@ -146,7 +146,7 @@ where
 			};
 		Resources::<T>::insert((collection_id, nft_id, resource_id), res);
 
-		Self::deposit_event(Event::ResourceAdded { collection_id, nft_id, resource_id });
+		Self::deposit_event(Event::ResourceAdded { nft_id, resource_id, collection_id });
 
 		Ok(resource_id)
 	}
@@ -157,6 +157,10 @@ where
 		nft_id: NftId,
 		resource_id: ResourceId,
 	) -> DispatchResult {
+		ensure!(
+			Resources::<T>::get((collection_id, nft_id, resource_id)).is_some(),
+			Error::<T>::ResourceDoesntExist
+		);
 		Resources::<T>::try_mutate_exists(
 			(collection_id, nft_id, resource_id),
 			|resource| -> DispatchResult {
@@ -168,7 +172,7 @@ where
 			},
 		)?;
 
-		Self::deposit_event(Event::ResourceAccepted { collection_id, nft_id, resource_id });
+		Self::deposit_event(Event::ResourceAccepted { nft_id, resource_id, collection_id });
 
 		Ok(())
 	}
@@ -199,7 +203,7 @@ where
 			Resources::<T>::remove((collection_id, nft_id, resource_id));
 		}
 
-		Self::deposit_event(Event::ResourceRemoval { collection_id, nft_id, resource_id });
+		Self::deposit_event(Event::ResourceRemoval { nft_id, resource_id, collection_id });
 
 		Ok(())
 	}
@@ -226,7 +230,7 @@ where
 			},
 		)?;
 
-		Self::deposit_event(Event::ResourceRemovalAccepted { collection_id, nft_id, resource_id });
+		Self::deposit_event(Event::ResourceRemovalAccepted { nft_id, resource_id, collection_id });
 
 		Ok(())
 	}
@@ -538,7 +542,7 @@ where
 		// Call pallet uniques to ensure NFT is burned
 		pallet_uniques::Pallet::<T>::do_burn(collection_id, nft_id, |_, _| Ok(()))?;
 
-		Self::deposit_event(Event::NFTBurned { owner, collection_id, nft_id });
+		Self::deposit_event(Event::NFTBurned { owner, nft_id, collection_id });
 
 		Ok((collection_id, nft_id))
 	}

--- a/pallets/rmrk-core/src/functions.rs
+++ b/pallets/rmrk-core/src/functions.rs
@@ -6,7 +6,11 @@
 
 use super::*;
 use codec::{Codec, Decode, Encode};
-use frame_support::traits::{tokens::Locker, Get};
+use frame_support::{
+	pallet_prelude::*,
+	traits::{tokens::Locker, Get},
+};
+use frame_system::Origin;
 
 use sp_runtime::{
 	traits::{Saturating, TrailingZeroInput},
@@ -24,15 +28,11 @@ where
 	T: pallet_uniques::Config<CollectionId = CollectionId, ItemId = NftId>,
 {
 	fn priority_set(
-		sender: T::AccountId,
+		_sender: T::AccountId,
 		collection_id: CollectionId,
 		nft_id: NftId,
 		priorities: BoundedVec<ResourceId, T::MaxPriorities>,
 	) -> DispatchResult {
-		let (root_owner, _) = Pallet::<T>::lookup_root_owner(collection_id, nft_id)?;
-		ensure!(sender == root_owner, Error::<T>::NoPermission);
-		// Check NFT lock status
-		ensure!(!Pallet::<T>::is_locked(collection_id, nft_id), pallet_uniques::Error::<T>::Locked);
 		Priorities::<T>::remove_prefix((collection_id, nft_id), None);
 		let mut priority_index = 0;
 		for resource_id in priorities {
@@ -106,24 +106,17 @@ where
 	T: pallet_uniques::Config<CollectionId = CollectionId, ItemId = NftId>,
 {
 	fn resource_add(
-		sender: T::AccountId,
+		_sender: T::AccountId,
 		collection_id: CollectionId,
 		nft_id: NftId,
 		resource: ResourceTypes<BoundedVec<u8, T::StringLimit>, BoundedVec<PartId, T::PartsLimit>>,
-		adding_on_mint: bool,
+		pending: bool,
 		resource_id: ResourceId,
 	) -> Result<ResourceId, DispatchError> {
 		ensure!(
 			Resources::<T>::get((collection_id, nft_id, resource_id)).is_none(),
 			Error::<T>::ResourceAlreadyExists
 		);
-
-		let collection = Self::collections(collection_id).ok_or(Error::<T>::CollectionUnknown)?;
-
-		ensure!(collection.issuer == sender, Error::<T>::NoPermission);
-		let (root_owner, _) = Pallet::<T>::lookup_root_owner(collection_id, nft_id)?;
-		// Check NFT lock status
-		ensure!(!Pallet::<T>::is_locked(collection_id, nft_id), pallet_uniques::Error::<T>::Locked);
 
 		match resource.clone() {
 			ResourceTypes::Basic(_r) => (),
@@ -144,15 +137,6 @@ where
 			},
 		}
 
-		// Resource should be in a pending state if the rootowner of the resource is not the sender
-		// of the transaction, unless the resource is being added on mint.  This prevents the
-		// situation where an NFT being minted *directly to* a non-owned NFT *with resources* will
-		// have those resources be *pending*.  While the minted NFT itself will be pending, it is
-		// inefficent and unnecessary to have the resources also be pending.  Otherwise, in such a
-		// case, the owner would have to accept not only the NFT but also all originally-added
-		// resources.
-		let pending = (root_owner != sender) && !adding_on_mint;
-
 		let res: ResourceInfo<BoundedVec<u8, T::StringLimit>, BoundedVec<PartId, T::PartsLimit>> =
 			ResourceInfo::<BoundedVec<u8, T::StringLimit>, BoundedVec<PartId, T::PartsLimit>> {
 				id: resource_id,
@@ -162,50 +146,46 @@ where
 			};
 		Resources::<T>::insert((collection_id, nft_id, resource_id), res);
 
+		Self::deposit_event(Event::ResourceAdded { collection_id, nft_id, resource_id });
+
 		Ok(resource_id)
 	}
 
 	fn accept(
-		sender: T::AccountId,
+		_sender: T::AccountId,
 		collection_id: CollectionId,
 		nft_id: NftId,
 		resource_id: ResourceId,
 	) -> DispatchResult {
-		let (root_owner, _) = Pallet::<T>::lookup_root_owner(collection_id, nft_id)?;
-		ensure!(root_owner == sender, Error::<T>::NoPermission);
-		// Check NFT lock status
-		ensure!(!Pallet::<T>::is_locked(collection_id, nft_id), pallet_uniques::Error::<T>::Locked);
 		Resources::<T>::try_mutate_exists(
 			(collection_id, nft_id, resource_id),
 			|resource| -> DispatchResult {
-				if let Some(res) = resource {
+				if let Some(res) = resource.into_mut() {
+					ensure!(res.pending, Error::<T>::ResourceNotPending);
 					res.pending = false;
 				}
 				Ok(())
 			},
 		)?;
 
-		Self::deposit_event(Event::ResourceAccepted { nft_id, resource_id });
+		Self::deposit_event(Event::ResourceAccepted { collection_id, nft_id, resource_id });
+
 		Ok(())
 	}
 
 	fn resource_remove(
-		sender: T::AccountId,
+		_sender: T::AccountId,
 		collection_id: CollectionId,
 		nft_id: NftId,
 		resource_id: ResourceId,
+		pending_resource: bool,
 	) -> DispatchResult {
-		let collection = Self::collections(collection_id).ok_or(Error::<T>::CollectionUnknown)?;
-		let (root_owner, _) = Pallet::<T>::lookup_root_owner(collection_id, nft_id)?;
-		ensure!(collection.issuer == sender, Error::<T>::NoPermission);
 		ensure!(
 			Resources::<T>::contains_key((collection_id, nft_id, resource_id)),
 			Error::<T>::ResourceDoesntExist
 		);
 
-		if root_owner == sender {
-			Resources::<T>::remove((collection_id, nft_id, resource_id));
-		} else {
+		if pending_resource {
 			Resources::<T>::try_mutate_exists(
 				(collection_id, nft_id, resource_id),
 				|resource| -> DispatchResult {
@@ -215,19 +195,21 @@ where
 					Ok(())
 				},
 			)?;
+		} else {
+			Resources::<T>::remove((collection_id, nft_id, resource_id));
 		}
+
+		Self::deposit_event(Event::ResourceRemoval { collection_id, nft_id, resource_id });
 
 		Ok(())
 	}
 
 	fn accept_removal(
-		sender: T::AccountId,
+		_sender: T::AccountId,
 		collection_id: CollectionId,
 		nft_id: NftId,
 		resource_id: ResourceId,
 	) -> DispatchResult {
-		let (root_owner, _) = Pallet::<T>::lookup_root_owner(collection_id, nft_id)?;
-		ensure!(root_owner == sender, Error::<T>::NoPermission);
 		ensure!(
 			Resources::<T>::contains_key((collection_id, nft_id, &resource_id)),
 			Error::<T>::ResourceDoesntExist
@@ -243,6 +225,8 @@ where
 				Ok(())
 			},
 		)?;
+
+		Self::deposit_event(Event::ResourceRemovalAccepted { collection_id, nft_id, resource_id });
 
 		Ok(())
 	}
@@ -289,10 +273,23 @@ where
 		Ok(collection_id)
 	}
 
-	fn collection_burn(_issuer: T::AccountId, collection_id: CollectionId) -> DispatchResult {
+	fn collection_burn(issuer: T::AccountId, collection_id: CollectionId) -> DispatchResult {
 		let collection = Self::collections(collection_id).ok_or(Error::<T>::CollectionUnknown)?;
 		ensure!(collection.nfts_count == 0, Error::<T>::CollectionNotEmpty);
+		// Get DestroyWitness for Uniques pallet
+		let witness = pallet_uniques::Pallet::<T>::get_destroy_witness(&collection_id)
+			.ok_or(Error::<T>::NoWitness)?;
+		ensure!(witness.items == 0u32, Error::<T>::CollectionNotEmpty);
+		// Remove from RMRK storage
 		Collections::<T>::remove(collection_id);
+
+		pallet_uniques::Pallet::<T>::do_destroy_collection(
+			collection_id,
+			witness,
+			issuer.clone().into(),
+		)?;
+
+		Self::deposit_event(Event::CollectionDestroyed { issuer, collection_id });
 		Ok(())
 	}
 
@@ -318,10 +315,12 @@ where
 	) -> Result<CollectionId, DispatchError> {
 		Collections::<T>::try_mutate_exists(collection_id, |collection| -> DispatchResult {
 			let collection = collection.as_mut().ok_or(Error::<T>::CollectionUnknown)?;
-			ensure!(collection.issuer == sender, Error::<T>::NoPermission);
 			collection.max = Some(collection.nfts_count);
 			Ok(())
 		})?;
+
+		Self::deposit_event(Event::CollectionLocked { issuer: sender, collection_id });
+
 		Ok(collection_id)
 	}
 }
@@ -487,7 +486,7 @@ where
 					collection_id,
 					nft_id,
 					res.resource,
-					true,
+					false,
 					res.id,
 				)?;
 			}
@@ -503,6 +502,7 @@ where
 	}
 
 	fn nft_burn(
+		owner: T::AccountId,
 		collection_id: CollectionId,
 		nft_id: NftId,
 		max_recursions: u32,
@@ -525,7 +525,7 @@ where
 		for ((child_collection_id, child_nft_id), _) in
 			Children::<T>::drain_prefix((collection_id, nft_id))
 		{
-			Self::nft_burn(child_collection_id, child_nft_id, max_recursions - 1)?;
+			Self::nft_burn(owner.clone(), child_collection_id, child_nft_id, max_recursions - 1)?;
 		}
 
 		// decrement nfts counter
@@ -534,6 +534,11 @@ where
 			collection.nfts_count.saturating_dec();
 			Ok(())
 		})?;
+
+		// Call pallet uniques to ensure NFT is burned
+		pallet_uniques::Pallet::<T>::do_burn(collection_id, nft_id, |_, _| Ok(()))?;
+
+		Self::deposit_event(Event::NFTBurned { owner, collection_id, nft_id });
 
 		Ok((collection_id, nft_id))
 	}
@@ -594,7 +599,7 @@ where
 			},
 		};
 
-		sending_nft.owner = new_owner;
+		sending_nft.owner = new_owner.clone();
 		// Nfts::<T>::insert(collection_id, nft_id, sending_nft);
 
 		if approval_required {
@@ -625,6 +630,21 @@ where
 			Pallet::<T>::add_child(new_owner_cid_nid, (collection_id, nft_id));
 		}
 
+		pallet_uniques::Pallet::<T>::do_transfer(
+			collection_id,
+			nft_id,
+			new_owner_account.clone(),
+			|_class_details, _details| Ok(()),
+		)?;
+
+		Self::deposit_event(Event::NFTSent {
+			sender,
+			recipient: new_owner,
+			collection_id,
+			nft_id,
+			approval_required,
+		});
+
 		Ok((new_owner_account, approval_required))
 	}
 
@@ -644,7 +664,7 @@ where
 			Nfts::<T>::get(collection_id, nft_id).ok_or(Error::<T>::NoAvailableNftId)?;
 
 		// Prepare acceptance
-		let new_owner_account = match new_owner {
+		let new_owner_account = match new_owner.clone() {
 			AccountIdOrCollectionNftTuple::AccountId(id) => id,
 			AccountIdOrCollectionNftTuple::CollectionAndNftTuple(cid, nid) => {
 				// Check if NFT target exists
@@ -676,6 +696,20 @@ where
 			}
 			Ok(())
 		})?;
+
+		pallet_uniques::Pallet::<T>::do_transfer(
+			collection_id,
+			nft_id,
+			new_owner_account.clone(),
+			|_class_details, _details| Ok(()),
+		)?;
+
+		Self::deposit_event(Event::NFTAccepted {
+			sender,
+			recipient: new_owner,
+			collection_id,
+			nft_id,
+		});
 
 		Ok((new_owner_account, collection_id, nft_id))
 	}
@@ -715,7 +749,7 @@ where
 		let mut rejecting_nft =
 			Nfts::<T>::get(collection_id, nft_id).ok_or(Error::<T>::NoAvailableNftId)?;
 
-		Self::nft_burn(collection_id, nft_id, max_recursions)?;
+		Self::nft_burn(sender.clone(), collection_id, nft_id, max_recursions)?;
 
 		Ok((sender, collection_id, nft_id))
 	}

--- a/pallets/rmrk-core/src/lib.rs
+++ b/pallets/rmrk-core/src/lib.rs
@@ -254,8 +254,8 @@ pub mod pallet {
 		},
 		NFTBurned {
 			owner: T::AccountId,
-			collection_id: CollectionId,
 			nft_id: NftId,
+			collection_id: CollectionId,
 		},
 		CollectionDestroyed {
 			issuer: T::AccountId,
@@ -300,24 +300,24 @@ pub mod pallet {
 			collection_id: CollectionId,
 		},
 		ResourceAdded {
-			collection_id: CollectionId,
 			nft_id: NftId,
 			resource_id: ResourceId,
+			collection_id: CollectionId,
 		},
 		ResourceAccepted {
-			collection_id: CollectionId,
 			nft_id: NftId,
 			resource_id: ResourceId,
+			collection_id: CollectionId,
 		},
 		ResourceRemoval {
-			collection_id: CollectionId,
 			nft_id: NftId,
 			resource_id: ResourceId,
+			collection_id: CollectionId,
 		},
 		ResourceRemovalAccepted {
-			collection_id: CollectionId,
 			nft_id: NftId,
 			resource_id: ResourceId,
+			collection_id: CollectionId,
 		},
 		PrioritySet {
 			collection_id: CollectionId,

--- a/pallets/rmrk-core/src/lib.rs
+++ b/pallets/rmrk-core/src/lib.rs
@@ -7,7 +7,10 @@
 #![allow(clippy::too_many_arguments)]
 
 use frame_support::{
-	dispatch::DispatchResult, ensure, traits::tokens::nonfungibles::*, transactional, BoundedVec,
+	dispatch::DispatchResult,
+	ensure,
+	traits::tokens::{nonfungibles::*, Locker},
+	transactional, BoundedVec,
 };
 use frame_system::ensure_signed;
 
@@ -251,6 +254,7 @@ pub mod pallet {
 		},
 		NFTBurned {
 			owner: T::AccountId,
+			collection_id: CollectionId,
 			nft_id: NftId,
 		},
 		CollectionDestroyed {
@@ -296,18 +300,22 @@ pub mod pallet {
 			collection_id: CollectionId,
 		},
 		ResourceAdded {
+			collection_id: CollectionId,
 			nft_id: NftId,
 			resource_id: ResourceId,
 		},
 		ResourceAccepted {
+			collection_id: CollectionId,
 			nft_id: NftId,
 			resource_id: ResourceId,
 		},
 		ResourceRemoval {
+			collection_id: CollectionId,
 			nft_id: NftId,
 			resource_id: ResourceId,
 		},
 		ResourceRemovalAccepted {
+			collection_id: CollectionId,
 			nft_id: NftId,
 			resource_id: ResourceId,
 		},
@@ -491,11 +499,9 @@ pub mod pallet {
 			let (root_owner, _) = Pallet::<T>::lookup_root_owner(collection_id, nft_id)?;
 			// Check ownership
 			ensure!(sender == root_owner, Error::<T>::NoPermission);
-			let (_collection_id, nft_id) = Self::nft_burn(collection_id, nft_id, max_burns)?;
+			let (_collection_id, _nft_id) =
+				Self::nft_burn(root_owner, collection_id, nft_id, max_burns)?;
 
-			pallet_uniques::Pallet::<T>::do_burn(collection_id, nft_id, |_, _| Ok(()))?;
-
-			Self::deposit_event(Event::NFTBurned { owner: sender, nft_id });
 			Ok(())
 		}
 
@@ -508,19 +514,8 @@ pub mod pallet {
 		) -> DispatchResult {
 			let sender = ensure_signed(origin)?;
 
-			Self::collection_burn(sender.clone(), collection_id)?;
+			Self::collection_burn(sender, collection_id)?;
 
-			let witness = pallet_uniques::Pallet::<T>::get_destroy_witness(&collection_id)
-				.ok_or(Error::<T>::NoWitness)?;
-			ensure!(witness.items == 0u32, Error::<T>::CollectionNotEmpty);
-
-			pallet_uniques::Pallet::<T>::do_destroy_collection(
-				collection_id,
-				witness,
-				sender.clone().into(),
-			)?;
-
-			Self::deposit_event(Event::CollectionDestroyed { issuer: sender, collection_id });
 			Ok(())
 		}
 
@@ -541,23 +536,8 @@ pub mod pallet {
 		) -> DispatchResult {
 			let sender = ensure_signed(origin)?;
 
-			let (new_owner_account, approval_required) =
+			let (_new_owner_account, _approval_required) =
 				Self::nft_send(sender.clone(), collection_id, nft_id, new_owner.clone())?;
-
-			pallet_uniques::Pallet::<T>::do_transfer(
-				collection_id,
-				nft_id,
-				new_owner_account,
-				|_class_details, _details| Ok(()),
-			)?;
-
-			Self::deposit_event(Event::NFTSent {
-				sender,
-				recipient: new_owner.clone(),
-				collection_id,
-				nft_id,
-				approval_required,
-			});
 
 			Ok(())
 		}
@@ -683,10 +663,12 @@ pub mod pallet {
 			collection_id: CollectionId,
 		) -> DispatchResult {
 			let sender = ensure_signed(origin)?;
+			let collection =
+				Self::collections(collection_id).ok_or(Error::<T>::CollectionUnknown)?;
+			ensure!(collection.issuer == sender, Error::<T>::NoPermission);
 
-			let collection_id = Self::collection_lock(sender.clone(), collection_id)?;
+			let _collection_id = Self::collection_lock(sender.clone(), collection_id)?;
 
-			Self::deposit_event(Event::CollectionLocked { issuer: sender, collection_id });
 			Ok(())
 		}
 
@@ -701,17 +683,28 @@ pub mod pallet {
 			resource_id: ResourceId,
 		) -> DispatchResult {
 			let sender = ensure_signed(origin)?;
+			let collection =
+				Self::collections(collection_id).ok_or(Error::<T>::CollectionUnknown)?;
+
+			ensure!(collection.issuer == sender, Error::<T>::NoPermission);
+			let (root_owner, _) = Pallet::<T>::lookup_root_owner(collection_id, nft_id)?;
+			// Check NFT lock status
+			ensure!(
+				!Pallet::<T>::is_locked(collection_id, nft_id),
+				pallet_uniques::Error::<T>::Locked
+			);
+
+			let pending = root_owner != sender;
 
 			Self::resource_add(
 				sender,
 				collection_id,
 				nft_id,
 				ResourceTypes::Basic(resource),
-				false,
+				pending,
 				resource_id,
 			)?;
 
-			Self::deposit_event(Event::ResourceAdded { nft_id, resource_id });
 			Ok(())
 		}
 
@@ -727,16 +720,28 @@ pub mod pallet {
 		) -> DispatchResult {
 			let sender = ensure_signed(origin)?;
 
+			let collection =
+				Self::collections(collection_id).ok_or(Error::<T>::CollectionUnknown)?;
+
+			ensure!(collection.issuer == sender, Error::<T>::NoPermission);
+			let (root_owner, _) = Pallet::<T>::lookup_root_owner(collection_id, nft_id)?;
+			// Check NFT lock status
+			ensure!(
+				!Pallet::<T>::is_locked(collection_id, nft_id),
+				pallet_uniques::Error::<T>::Locked
+			);
+
+			let pending = (root_owner != sender);
+
 			Self::resource_add(
 				sender,
 				collection_id,
 				nft_id,
 				ResourceTypes::Composable(resource),
-				false,
+				pending,
 				resource_id,
 			)?;
 
-			Self::deposit_event(Event::ResourceAdded { nft_id, resource_id });
 			Ok(())
 		}
 
@@ -751,17 +756,28 @@ pub mod pallet {
 			resource_id: ResourceId,
 		) -> DispatchResult {
 			let sender = ensure_signed(origin)?;
+			let collection =
+				Self::collections(collection_id).ok_or(Error::<T>::CollectionUnknown)?;
+
+			ensure!(collection.issuer == sender, Error::<T>::NoPermission);
+			let (root_owner, _) = Pallet::<T>::lookup_root_owner(collection_id, nft_id)?;
+			// Check NFT lock status
+			ensure!(
+				!Pallet::<T>::is_locked(collection_id, nft_id),
+				pallet_uniques::Error::<T>::Locked
+			);
+
+			let pending = root_owner != sender;
 
 			Self::resource_add(
 				sender,
 				collection_id,
 				nft_id,
 				ResourceTypes::Slot(resource),
-				false,
+				pending,
 				resource_id,
 			)?;
 
-			Self::deposit_event(Event::ResourceAdded { nft_id, resource_id });
 			Ok(())
 		}
 
@@ -775,26 +791,13 @@ pub mod pallet {
 			resource_id: ResourceId,
 		) -> DispatchResult {
 			let sender = ensure_signed(origin)?;
-			ensure!(
-				Resources::<T>::get((collection_id, nft_id, resource_id)).is_some(),
-				Error::<T>::ResourceDoesntExist
-			);
-
 			let (owner, _) = Pallet::<T>::lookup_root_owner(collection_id, nft_id)?;
 			ensure!(owner == sender, Error::<T>::NoPermission);
+			// Check NFT lock status
+			ensure!(!Self::is_locked(collection_id, nft_id), pallet_uniques::Error::<T>::Locked);
 
-			Resources::<T>::try_mutate_exists(
-				(collection_id, nft_id, resource_id),
-				|resource| -> DispatchResult {
-					if let Some(res) = resource.into_mut() {
-						ensure!(res.pending, Error::<T>::ResourceNotPending);
-						res.pending = false;
-					}
-					Ok(())
-				},
-			)?;
+			Self::accept(sender, collection_id, nft_id, resource_id)?;
 
-			Self::deposit_event(Event::ResourceAccepted { nft_id, resource_id });
 			Ok(())
 		}
 
@@ -808,10 +811,16 @@ pub mod pallet {
 			resource_id: ResourceId,
 		) -> DispatchResult {
 			let sender = ensure_signed(origin)?;
+			let collection =
+				Self::collections(collection_id).ok_or(Error::<T>::CollectionUnknown)?;
+			let (root_owner, _) = Pallet::<T>::lookup_root_owner(collection_id, nft_id)?;
+			ensure!(collection.issuer == sender, Error::<T>::NoPermission);
 
-			Self::resource_remove(sender, collection_id, nft_id, resource_id)?;
+			// Pending resource if sender is not root owner
+			let pending_resource = !(sender == root_owner);
 
-			Self::deposit_event(Event::ResourceRemoval { nft_id, resource_id });
+			Self::resource_remove(sender, collection_id, nft_id, resource_id, pending_resource)?;
+
 			Ok(())
 		}
 
@@ -826,9 +835,11 @@ pub mod pallet {
 		) -> DispatchResult {
 			let sender = ensure_signed(origin)?;
 
+			let (root_owner, _) = Pallet::<T>::lookup_root_owner(collection_id, nft_id)?;
+			ensure!(root_owner == sender, Error::<T>::NoPermission);
+
 			Self::accept_removal(sender, collection_id, nft_id, resource_id)?;
 
-			Self::deposit_event(Event::ResourceRemovalAccepted { nft_id, resource_id });
 			Ok(())
 		}
 
@@ -842,8 +853,13 @@ pub mod pallet {
 			priorities: BoundedVec<ResourceId, T::MaxPriorities>,
 		) -> DispatchResult {
 			let sender = ensure_signed(origin)?;
+			let (root_owner, _) = Pallet::<T>::lookup_root_owner(collection_id, nft_id)?;
+			ensure!(sender == root_owner, Error::<T>::NoPermission);
+			// Check NFT lock status
+			ensure!(!Self::is_locked(collection_id, nft_id), pallet_uniques::Error::<T>::Locked);
+
 			Self::priority_set(sender, collection_id, nft_id, priorities)?;
-			Self::deposit_event(Event::PrioritySet { collection_id, nft_id });
+
 			Ok(())
 		}
 	}

--- a/pallets/rmrk-core/src/tests.rs
+++ b/pallets/rmrk-core/src/tests.rs
@@ -1005,8 +1005,8 @@ fn burn_nft_works() {
 		// Successful burn creates NFTBurned event
 		System::assert_last_event(MockEvent::RmrkCore(crate::Event::NFTBurned {
 			owner: ALICE,
-			collection_id: 0,
 			nft_id: 0,
+			collection_id: 0,
 		}));
 		// NFT count of collection is now 0
 		assert_eq!(RMRKCore::collections(COLLECTION_ID_0).unwrap().nfts_count, 0);
@@ -1208,9 +1208,9 @@ fn create_resource_works() {
 		));
 		// Successful resource addition should trigger ResourceAdded event
 		System::assert_last_event(MockEvent::RmrkCore(crate::Event::ResourceAdded {
-			collection_id: 0,
 			nft_id: 0,
 			resource_id: 0, // resource_id
+			collection_id: 0,
 		}));
 		// Since ALICE rootowns NFT, pending status of resource should be false
 		assert_eq!(RMRKCore::resources((0, 0, 0)).unwrap().pending, false);
@@ -1369,9 +1369,9 @@ fn add_resource_pending_works() {
 		assert_ok!(RMRKCore::accept_resource(Origin::signed(BOB), 0, 0, 0));
 		// Valid resource acceptance should trigger a ResourceAccepted event
 		System::assert_last_event(MockEvent::RmrkCore(crate::Event::ResourceAccepted {
-			collection_id: 0,
 			nft_id: 0,
 			resource_id: 0, // resource_id
+			collection_id: 0,
 		}));
 		// Resource should now have false pending status
 		assert_eq!(RMRKCore::resources((0, 0, 0)).unwrap().pending, false);
@@ -1431,9 +1431,9 @@ fn resource_removal_works() {
 		));
 		// Successful resource removal should trigger ResourceRemoval event
 		System::assert_last_event(MockEvent::RmrkCore(crate::Event::ResourceRemoval {
-			collection_id: 0,
 			nft_id: 0,
 			resource_id: 0, // resource_id
+			collection_id: 0,
 		}));
 		// Since ALICE rootowns NFT, resource should be removed
 		assert_eq!(RMRKCore::resources((0, 0, 0)), None);
@@ -1509,9 +1509,9 @@ fn resource_removal_pending_works() {
 		assert_ok!(RMRKCore::accept_resource_removal(Origin::signed(BOB), 0, 0, 0));
 		// Successful resource removal acceptance should trigger ResourceRemovalAccepted event
 		System::assert_last_event(MockEvent::RmrkCore(crate::Event::ResourceRemovalAccepted {
-			collection_id: 0,
 			nft_id: 0,
 			resource_id: 0, // resource_id
+			collection_id: 0,
 		}));
 		// Resource removed
 		assert_eq!(RMRKCore::resources((0, 0, 0)), None);

--- a/pallets/rmrk-core/src/tests.rs
+++ b/pallets/rmrk-core/src/tests.rs
@@ -1005,6 +1005,7 @@ fn burn_nft_works() {
 		// Successful burn creates NFTBurned event
 		System::assert_last_event(MockEvent::RmrkCore(crate::Event::NFTBurned {
 			owner: ALICE,
+			collection_id: 0,
 			nft_id: 0,
 		}));
 		// NFT count of collection is now 0
@@ -1207,6 +1208,7 @@ fn create_resource_works() {
 		));
 		// Successful resource addition should trigger ResourceAdded event
 		System::assert_last_event(MockEvent::RmrkCore(crate::Event::ResourceAdded {
+			collection_id: 0,
 			nft_id: 0,
 			resource_id: 0, // resource_id
 		}));
@@ -1367,6 +1369,7 @@ fn add_resource_pending_works() {
 		assert_ok!(RMRKCore::accept_resource(Origin::signed(BOB), 0, 0, 0));
 		// Valid resource acceptance should trigger a ResourceAccepted event
 		System::assert_last_event(MockEvent::RmrkCore(crate::Event::ResourceAccepted {
+			collection_id: 0,
 			nft_id: 0,
 			resource_id: 0, // resource_id
 		}));
@@ -1428,6 +1431,7 @@ fn resource_removal_works() {
 		));
 		// Successful resource removal should trigger ResourceRemoval event
 		System::assert_last_event(MockEvent::RmrkCore(crate::Event::ResourceRemoval {
+			collection_id: 0,
 			nft_id: 0,
 			resource_id: 0, // resource_id
 		}));
@@ -1505,6 +1509,7 @@ fn resource_removal_pending_works() {
 		assert_ok!(RMRKCore::accept_resource_removal(Origin::signed(BOB), 0, 0, 0));
 		// Successful resource removal acceptance should trigger ResourceRemovalAccepted event
 		System::assert_last_event(MockEvent::RmrkCore(crate::Event::ResourceRemovalAccepted {
+			collection_id: 0,
 			nft_id: 0,
 			resource_id: 0, // resource_id
 		}));

--- a/tests/src/addResource.test.ts
+++ b/tests/src/addResource.test.ts
@@ -492,7 +492,7 @@ describe("integration test: add NFT resource", () => {
 
     const tx = acceptNftResource(
       api,
-      Bob,
+      Alice,
       collectionIdBob,
       wrongNft,
       resourceId

--- a/tests/src/interfaces/augment-api-events.ts
+++ b/tests/src/interfaces/augment-api-events.ts
@@ -81,17 +81,17 @@ declare module '@polkadot/api-base/types/events' {
       CollectionLocked: AugmentedEvent<ApiType, [issuer: AccountId32, collectionId: u32], { issuer: AccountId32, collectionId: u32 }>;
       IssuerChanged: AugmentedEvent<ApiType, [oldIssuer: AccountId32, newIssuer: AccountId32, collectionId: u32], { oldIssuer: AccountId32, newIssuer: AccountId32, collectionId: u32 }>;
       NFTAccepted: AugmentedEvent<ApiType, [sender: AccountId32, recipient: RmrkTraitsNftAccountIdOrCollectionNftTuple, collectionId: u32, nftId: u32], { sender: AccountId32, recipient: RmrkTraitsNftAccountIdOrCollectionNftTuple, collectionId: u32, nftId: u32 }>;
-      NFTBurned: AugmentedEvent<ApiType, [owner: AccountId32, nftId: u32], { owner: AccountId32, nftId: u32 }>;
+      NFTBurned: AugmentedEvent<ApiType, [owner: AccountId32, collectionId: u32, nftId: u32], { owner: AccountId32, collectionId: u32, nftId: u32 }>;
       NftMinted: AugmentedEvent<ApiType, [owner: RmrkTraitsNftAccountIdOrCollectionNftTuple, collectionId: u32, nftId: u32], { owner: RmrkTraitsNftAccountIdOrCollectionNftTuple, collectionId: u32, nftId: u32 }>;
       NFTRejected: AugmentedEvent<ApiType, [sender: AccountId32, collectionId: u32, nftId: u32], { sender: AccountId32, collectionId: u32, nftId: u32 }>;
       NFTSent: AugmentedEvent<ApiType, [sender: AccountId32, recipient: RmrkTraitsNftAccountIdOrCollectionNftTuple, collectionId: u32, nftId: u32, approvalRequired: bool], { sender: AccountId32, recipient: RmrkTraitsNftAccountIdOrCollectionNftTuple, collectionId: u32, nftId: u32, approvalRequired: bool }>;
       PrioritySet: AugmentedEvent<ApiType, [collectionId: u32, nftId: u32], { collectionId: u32, nftId: u32 }>;
       PropertyRemoved: AugmentedEvent<ApiType, [collectionId: u32, maybeNftId: Option<u32>, key: Bytes], { collectionId: u32, maybeNftId: Option<u32>, key: Bytes }>;
       PropertySet: AugmentedEvent<ApiType, [collectionId: u32, maybeNftId: Option<u32>, key: Bytes, value: Bytes], { collectionId: u32, maybeNftId: Option<u32>, key: Bytes, value: Bytes }>;
-      ResourceAccepted: AugmentedEvent<ApiType, [nftId: u32, resourceId: u32], { nftId: u32, resourceId: u32 }>;
-      ResourceAdded: AugmentedEvent<ApiType, [nftId: u32, resourceId: u32], { nftId: u32, resourceId: u32 }>;
-      ResourceRemoval: AugmentedEvent<ApiType, [nftId: u32, resourceId: u32], { nftId: u32, resourceId: u32 }>;
-      ResourceRemovalAccepted: AugmentedEvent<ApiType, [nftId: u32, resourceId: u32], { nftId: u32, resourceId: u32 }>;
+      ResourceAccepted: AugmentedEvent<ApiType, [collectionId: u32, nftId: u32, resourceId: u32], { collectionId: u32, nftId: u32, resourceId: u32 }>;
+      ResourceAdded: AugmentedEvent<ApiType, [collectionId: u32, nftId: u32, resourceId: u32], { collectionId: u32, nftId: u32, resourceId: u32 }>;
+      ResourceRemoval: AugmentedEvent<ApiType, [collectionId: u32, nftId: u32, resourceId: u32], { collectionId: u32, nftId: u32, resourceId: u32 }>;
+      ResourceRemovalAccepted: AugmentedEvent<ApiType, [collectionId: u32, nftId: u32, resourceId: u32], { collectionId: u32, nftId: u32, resourceId: u32 }>;
       /**
        * Generic event
        **/

--- a/tests/src/interfaces/augment-api-events.ts
+++ b/tests/src/interfaces/augment-api-events.ts
@@ -81,17 +81,17 @@ declare module '@polkadot/api-base/types/events' {
       CollectionLocked: AugmentedEvent<ApiType, [issuer: AccountId32, collectionId: u32], { issuer: AccountId32, collectionId: u32 }>;
       IssuerChanged: AugmentedEvent<ApiType, [oldIssuer: AccountId32, newIssuer: AccountId32, collectionId: u32], { oldIssuer: AccountId32, newIssuer: AccountId32, collectionId: u32 }>;
       NFTAccepted: AugmentedEvent<ApiType, [sender: AccountId32, recipient: RmrkTraitsNftAccountIdOrCollectionNftTuple, collectionId: u32, nftId: u32], { sender: AccountId32, recipient: RmrkTraitsNftAccountIdOrCollectionNftTuple, collectionId: u32, nftId: u32 }>;
-      NFTBurned: AugmentedEvent<ApiType, [owner: AccountId32, collectionId: u32, nftId: u32], { owner: AccountId32, collectionId: u32, nftId: u32 }>;
+      NFTBurned: AugmentedEvent<ApiType, [owner: AccountId32, nftId: u32, collectionId: u32], { owner: AccountId32, nftId: u32, collectionId: u32 }>;
       NftMinted: AugmentedEvent<ApiType, [owner: RmrkTraitsNftAccountIdOrCollectionNftTuple, collectionId: u32, nftId: u32], { owner: RmrkTraitsNftAccountIdOrCollectionNftTuple, collectionId: u32, nftId: u32 }>;
       NFTRejected: AugmentedEvent<ApiType, [sender: AccountId32, collectionId: u32, nftId: u32], { sender: AccountId32, collectionId: u32, nftId: u32 }>;
       NFTSent: AugmentedEvent<ApiType, [sender: AccountId32, recipient: RmrkTraitsNftAccountIdOrCollectionNftTuple, collectionId: u32, nftId: u32, approvalRequired: bool], { sender: AccountId32, recipient: RmrkTraitsNftAccountIdOrCollectionNftTuple, collectionId: u32, nftId: u32, approvalRequired: bool }>;
-      PrioritySet: AugmentedEvent<ApiType, [collectionId: u32, nftId: u32], { collectionId: u32, nftId: u32 }>;
       PropertyRemoved: AugmentedEvent<ApiType, [collectionId: u32, maybeNftId: Option<u32>, key: Bytes], { collectionId: u32, maybeNftId: Option<u32>, key: Bytes }>;
+      PrioritySet: AugmentedEvent<ApiType, [collectionId: u32, nftId: u32], { collectionId: u32, nftId: u32 }>;
       PropertySet: AugmentedEvent<ApiType, [collectionId: u32, maybeNftId: Option<u32>, key: Bytes, value: Bytes], { collectionId: u32, maybeNftId: Option<u32>, key: Bytes, value: Bytes }>;
-      ResourceAccepted: AugmentedEvent<ApiType, [collectionId: u32, nftId: u32, resourceId: u32], { collectionId: u32, nftId: u32, resourceId: u32 }>;
-      ResourceAdded: AugmentedEvent<ApiType, [collectionId: u32, nftId: u32, resourceId: u32], { collectionId: u32, nftId: u32, resourceId: u32 }>;
-      ResourceRemoval: AugmentedEvent<ApiType, [collectionId: u32, nftId: u32, resourceId: u32], { collectionId: u32, nftId: u32, resourceId: u32 }>;
-      ResourceRemovalAccepted: AugmentedEvent<ApiType, [collectionId: u32, nftId: u32, resourceId: u32], { collectionId: u32, nftId: u32, resourceId: u32 }>;
+      ResourceAccepted: AugmentedEvent<ApiType, [nftId: u32, resourceId: u32, collectionId: u32], { nftId: u32, resourceId: u32, collectionId: u32 }>;
+      ResourceAdded: AugmentedEvent<ApiType, [nftId: u32, resourceId: u32, collectionId: u32], { nftId: u32, resourceId: u32, collectionId: u32 }>;
+      ResourceRemoval: AugmentedEvent<ApiType, [nftId: u32, resourceId: u32, collectionId: u32], { nftId: u32, resourceId: u32, collectionId: u32 }>;
+      ResourceRemovalAccepted: AugmentedEvent<ApiType, [nftId: u32, resourceId: u32, collectionId: u32], { nftId: u32, resourceId: u32, collectionId: u32 }>;
       /**
        * Generic event
        **/

--- a/tests/src/interfaces/lookup.ts
+++ b/tests/src/interfaces/lookup.ts
@@ -312,8 +312,8 @@ export default {
       },
       NFTBurned: {
         owner: 'AccountId32',
-        collectionId: 'u32',
         nftId: 'u32',
+        collectionId: 'u32',
       },
       CollectionDestroyed: {
         issuer: 'AccountId32',
@@ -358,24 +358,24 @@ export default {
         collectionId: 'u32',
       },
       ResourceAdded: {
-        collectionId: 'u32',
         nftId: 'u32',
         resourceId: 'u32',
+        collectionId: 'u32',
       },
       ResourceAccepted: {
-        collectionId: 'u32',
         nftId: 'u32',
         resourceId: 'u32',
+        collectionId: 'u32',
       },
       ResourceRemoval: {
-        collectionId: 'u32',
         nftId: 'u32',
         resourceId: 'u32',
+        collectionId: 'u32',
       },
       ResourceRemovalAccepted: {
-        collectionId: 'u32',
         nftId: 'u32',
         resourceId: 'u32',
+        collectionId: 'u32',
       },
       PrioritySet: {
         collectionId: 'u32',

--- a/tests/src/interfaces/lookup.ts
+++ b/tests/src/interfaces/lookup.ts
@@ -312,6 +312,7 @@ export default {
       },
       NFTBurned: {
         owner: 'AccountId32',
+        collectionId: 'u32',
         nftId: 'u32',
       },
       CollectionDestroyed: {
@@ -357,18 +358,22 @@ export default {
         collectionId: 'u32',
       },
       ResourceAdded: {
+        collectionId: 'u32',
         nftId: 'u32',
         resourceId: 'u32',
       },
       ResourceAccepted: {
+        collectionId: 'u32',
         nftId: 'u32',
         resourceId: 'u32',
       },
       ResourceRemoval: {
+        collectionId: 'u32',
         nftId: 'u32',
         resourceId: 'u32',
       },
       ResourceRemovalAccepted: {
+        collectionId: 'u32',
         nftId: 'u32',
         resourceId: 'u32',
       },

--- a/tests/src/interfaces/rmrk/types.ts
+++ b/tests/src/interfaces/rmrk/types.ts
@@ -629,8 +629,8 @@ export interface PalletRmrkCoreEvent extends Enum {
   readonly isNftBurned: boolean;
   readonly asNftBurned: {
     readonly owner: AccountId32;
-    readonly collectionId: u32;
     readonly nftId: u32;
+    readonly collectionId: u32;
   } & Struct;
   readonly isCollectionDestroyed: boolean;
   readonly asCollectionDestroyed: {
@@ -684,27 +684,27 @@ export interface PalletRmrkCoreEvent extends Enum {
   } & Struct;
   readonly isResourceAdded: boolean;
   readonly asResourceAdded: {
-    readonly collectionId: u32;
     readonly nftId: u32;
     readonly resourceId: u32;
+    readonly collectionId: u32;
   } & Struct;
   readonly isResourceAccepted: boolean;
   readonly asResourceAccepted: {
-    readonly collectionId: u32;
     readonly nftId: u32;
     readonly resourceId: u32;
+    readonly collectionId: u32;
   } & Struct;
   readonly isResourceRemoval: boolean;
   readonly asResourceRemoval: {
-    readonly collectionId: u32;
     readonly nftId: u32;
     readonly resourceId: u32;
+    readonly collectionId: u32;
   } & Struct;
   readonly isResourceRemovalAccepted: boolean;
   readonly asResourceRemovalAccepted: {
-    readonly collectionId: u32;
     readonly nftId: u32;
     readonly resourceId: u32;
+    readonly collectionId: u32;
   } & Struct;
   readonly isPrioritySet: boolean;
   readonly asPrioritySet: {

--- a/tests/src/interfaces/rmrk/types.ts
+++ b/tests/src/interfaces/rmrk/types.ts
@@ -629,6 +629,7 @@ export interface PalletRmrkCoreEvent extends Enum {
   readonly isNftBurned: boolean;
   readonly asNftBurned: {
     readonly owner: AccountId32;
+    readonly collectionId: u32;
     readonly nftId: u32;
   } & Struct;
   readonly isCollectionDestroyed: boolean;
@@ -683,21 +684,25 @@ export interface PalletRmrkCoreEvent extends Enum {
   } & Struct;
   readonly isResourceAdded: boolean;
   readonly asResourceAdded: {
+    readonly collectionId: u32;
     readonly nftId: u32;
     readonly resourceId: u32;
   } & Struct;
   readonly isResourceAccepted: boolean;
   readonly asResourceAccepted: {
+    readonly collectionId: u32;
     readonly nftId: u32;
     readonly resourceId: u32;
   } & Struct;
   readonly isResourceRemoval: boolean;
   readonly asResourceRemoval: {
+    readonly collectionId: u32;
     readonly nftId: u32;
     readonly resourceId: u32;
   } & Struct;
   readonly isResourceRemovalAccepted: boolean;
   readonly asResourceRemovalAccepted: {
+    readonly collectionId: u32;
     readonly nftId: u32;
     readonly resourceId: u32;
   } & Struct;

--- a/tests/src/interfaces/types-lookup.ts
+++ b/tests/src/interfaces/types-lookup.ts
@@ -328,6 +328,7 @@ declare module '@polkadot/types/lookup' {
     readonly isNftBurned: boolean;
     readonly asNftBurned: {
       readonly owner: AccountId32;
+      readonly collectionId: u32;
       readonly nftId: u32;
     } & Struct;
     readonly isCollectionDestroyed: boolean;
@@ -387,16 +388,19 @@ declare module '@polkadot/types/lookup' {
     } & Struct;
     readonly isResourceAccepted: boolean;
     readonly asResourceAccepted: {
+      readonly collectionId: u32;
       readonly nftId: u32;
       readonly resourceId: u32;
     } & Struct;
     readonly isResourceRemoval: boolean;
     readonly asResourceRemoval: {
+      readonly collectionId: u32;
       readonly nftId: u32;
       readonly resourceId: u32;
     } & Struct;
     readonly isResourceRemovalAccepted: boolean;
     readonly asResourceRemovalAccepted: {
+      readonly collectionId: u32;
       readonly nftId: u32;
       readonly resourceId: u32;
     } & Struct;

--- a/tests/src/interfaces/types-lookup.ts
+++ b/tests/src/interfaces/types-lookup.ts
@@ -328,8 +328,8 @@ declare module '@polkadot/types/lookup' {
     readonly isNftBurned: boolean;
     readonly asNftBurned: {
       readonly owner: AccountId32;
-      readonly collectionId: u32;
       readonly nftId: u32;
+      readonly collectionId: u32;
     } & Struct;
     readonly isCollectionDestroyed: boolean;
     readonly asCollectionDestroyed: {
@@ -388,21 +388,21 @@ declare module '@polkadot/types/lookup' {
     } & Struct;
     readonly isResourceAccepted: boolean;
     readonly asResourceAccepted: {
-      readonly collectionId: u32;
       readonly nftId: u32;
       readonly resourceId: u32;
+      readonly collectionId: u32;
     } & Struct;
     readonly isResourceRemoval: boolean;
     readonly asResourceRemoval: {
-      readonly collectionId: u32;
       readonly nftId: u32;
       readonly resourceId: u32;
+      readonly collectionId: u32;
     } & Struct;
     readonly isResourceRemovalAccepted: boolean;
     readonly asResourceRemovalAccepted: {
-      readonly collectionId: u32;
       readonly nftId: u32;
       readonly resourceId: u32;
+      readonly collectionId: u32;
     } & Struct;
     readonly isPrioritySet: boolean;
     readonly asPrioritySet: {

--- a/tests/src/util/tx.ts
+++ b/tests/src/util/tx.ts
@@ -996,8 +996,9 @@ export async function acceptNftResource(
     "ResourceAccepted",
     (data) => {
       return {
-        nftId: parseInt(data[0].toString(), 10),
-        resourceId: parseInt(data[1].toString(), 10),
+        collectionId: parseInt(data[0].toString(), 10),
+        nftId: parseInt(data[1].toString(), 10),
+        resourceId: parseInt(data[2].toString(), 10),
       };
     }
   );

--- a/tests/src/util/tx.ts
+++ b/tests/src/util/tx.ts
@@ -996,9 +996,9 @@ export async function acceptNftResource(
     "ResourceAccepted",
     (data) => {
       return {
-        collectionId: parseInt(data[0].toString(), 10),
-        nftId: parseInt(data[1].toString(), 10),
-        resourceId: parseInt(data[2].toString(), 10),
+        nftId: parseInt(data[0].toString(), 10),
+        resourceId: parseInt(data[1].toString(), 10),
+        collectionId: parseInt(data[2].toString(), 10),
       };
     }
   );

--- a/traits/src/collection.rs
+++ b/traits/src/collection.rs
@@ -18,13 +18,11 @@ use sp_std::result::Result;
 #[derive(Encode, Decode, Debug, TypeInfo, MaxEncodedLen)]
 #[cfg_attr(
 	feature = "std",
-	serde(
-		bound = r#"
+	serde(bound = r#"
 			AccountId: Serialize,
 			BoundedString: AsRef<[u8]>,
 			BoundedSymbol: AsRef<[u8]>
-		"#
-	)
+		"#)
 )]
 pub struct CollectionInfo<BoundedString, BoundedSymbol, AccountId> {
 	/// Current bidder and bid price.

--- a/traits/src/nft.rs
+++ b/traits/src/nft.rs
@@ -98,6 +98,7 @@ pub trait Nft<AccountId, BoundedString, BoundedResourceVec> {
 		resources: Option<BoundedResourceVec>,
 	) -> Result<(CollectionId, NftId), DispatchError>;
 	fn nft_burn(
+		owner: AccountId,
 		collection_id: CollectionId,
 		nft_id: NftId,
 		max_burns: u32,

--- a/traits/src/resource.rs
+++ b/traits/src/resource.rs
@@ -128,7 +128,7 @@ pub trait Resource<BoundedString, AccountId, BoundedPart> {
 		collection_id: CollectionId,
 		nft_id: NftId,
 		resource: ResourceTypes<BoundedString, BoundedPart>,
-		adding_on_mint: bool,
+		pending: bool,
 		resource_id: ResourceId,
 	) -> Result<ResourceId, DispatchError>;
 	fn accept(
@@ -142,6 +142,7 @@ pub trait Resource<BoundedString, AccountId, BoundedPart> {
 		collection_id: CollectionId,
 		nft_id: NftId,
 		resource_id: ResourceId,
+		pending_resource: bool,
 	) -> DispatchResult;
 	fn accept_removal(
 		sender: AccountId,


### PR DESCRIPTION
Refactor User facing functions to emit Event in the internal functions and move permissions logic to the user facing functions.

Question:
- Should we move the `Lock` check to internal function or user facing function (Current solution uses first point)
  - Keeping them in user facing functions allows for downstream implementations to avoid adhering to a Lock during migrations and for custom pallet calls in the runtime to make changes that can bypass the lock
  - Putting them in the internal functions requires all downstream implementations to adhere to this logic and could cause complications for downstream 