### PR TITLE
Fix budget issue with Nested NFTs

### DIFF
--- a/tests/src/interfaces/rmrk/types.ts
+++ b/tests/src/interfaces/rmrk/types.ts
@@ -612,8 +612,9 @@ export interface PalletRmrkCoreError extends Enum {
   readonly isNonTransferable: boolean;
   readonly isCannotSendEquippedItem: boolean;
   readonly isCannotAcceptToNewOwner: boolean;
-  readonly isCannotSendNft: boolean;
-  readonly type: 'NoneValue' | 'StorageOverflow' | 'TooLong' | 'NoAvailableCollectionId' | 'NoAvailableResourceId' | 'MetadataNotSet' | 'RecipientNotSet' | 'NoAvailableNftId' | 'NotInRange' | 'RoyaltyNotSet' | 'CollectionUnknown' | 'NoPermission' | 'NoWitness' | 'CollectionNotEmpty' | 'CollectionFullOrLocked' | 'CannotSendToDescendentOrSelf' | 'ResourceAlreadyExists' | 'NftAlreadyExists' | 'EmptyResource' | 'TooManyRecursions' | 'NftIsLocked' | 'CannotAcceptNonOwnedNft' | 'CannotRejectNonOwnedNft' | 'CannotRejectNonPendingNft' | 'ResourceDoesntExist' | 'ResourceNotPending' | 'NonTransferable' | 'CannotSendEquippedItem' | 'CannotAcceptToNewOwner' | 'CannotSendNft';
+  readonly isFailedTransferHooksPreCheck: boolean;
+  readonly isFailedTransferHooksPostTransfer: boolean;
+  readonly type: 'NoneValue' | 'StorageOverflow' | 'TooLong' | 'NoAvailableCollectionId' | 'NoAvailableResourceId' | 'MetadataNotSet' | 'RecipientNotSet' | 'NoAvailableNftId' | 'NotInRange' | 'RoyaltyNotSet' | 'CollectionUnknown' | 'NoPermission' | 'NoWitness' | 'CollectionNotEmpty' | 'CollectionFullOrLocked' | 'CannotSendToDescendentOrSelf' | 'ResourceAlreadyExists' | 'NftAlreadyExists' | 'EmptyResource' | 'TooManyRecursions' | 'NftIsLocked' | 'CannotAcceptNonOwnedNft' | 'CannotRejectNonOwnedNft' | 'CannotRejectNonPendingNft' | 'ResourceDoesntExist' | 'ResourceNotPending' | 'NonTransferable' | 'CannotSendEquippedItem' | 'CannotAcceptToNewOwner' | 'FailedTransferHooksPreCheck' | 'FailedTransferHooksPostTransfer';
 }
 
 /** @name PalletRmrkCoreEvent */

--- a/traits/src/budget.rs
+++ b/traits/src/budget.rs
@@ -9,33 +9,47 @@ pub trait Budget {
 	/// Implementations should use interior mutabilitiy
 	fn consume_custom(&self, calls: u32) -> bool;
 
-	fn val(&self) -> u32 {
-		self.get_value()
+	fn budget_left_value(&self) -> u32 {
+		self.get_budget_left_value()
+	}
+	fn budget_consumed_value(&self) -> u32 {
+		self.get_budget_consumed_value()
 	}
 
-	fn get_value(&self) -> u32;
+	fn get_budget_left_value(&self) -> u32;
+	fn get_budget_consumed_value(&self) -> u32;
 }
 
-pub struct Value(Cell<u32>);
+pub struct Value {
+	budget_left: Cell<u32>,
+	budget_consumed: Cell<u32>,
+}
+
 impl Value {
 	pub fn new(v: u32) -> Self {
-		Self(Cell::new(v))
+		Self { budget_left: Cell::new(v), budget_consumed: Cell::new(0) }
 	}
 	pub fn refund(self) -> u32 {
-		self.0.get()
+		self.budget_left.get()
 	}
 }
 
 impl Budget for Value {
 	fn consume_custom(&self, calls: u32) -> bool {
-		let (result, overflown) = self.0.get().overflowing_sub(calls);
-		if overflown {
+		let (budget_left_result, sub_overflown) = self.budget_left.get().overflowing_sub(calls);
+		let (budget_consumed_result, add_overflown) =
+			self.budget_consumed.get().overflowing_add(calls);
+		if sub_overflown || add_overflown {
 			return false
 		}
-		self.0.set(result);
+		self.budget_left.set(budget_left_result);
+		self.budget_consumed.set(budget_consumed_result);
 		true
 	}
-	fn get_value(&self) -> u32 {
-		self.0.get()
+	fn get_budget_left_value(&self) -> u32 {
+		self.budget_left.get()
+	}
+	fn get_budget_consumed_value(&self) -> u32 {
+		self.budget_consumed.get()
 	}
 }


### PR DESCRIPTION
## Description
There are 2 problems with the current `Budget` trait:
1) NFTs are currently allowed to mint and send NFTs to a parent NFT that can meet up to the threshold of `NestingBudget::get() + 1`. This allows for NFTs queries like `lookup_root_owner` to return errors like `TooManyRecursions`. Having this error is okay, but the NFTs should be prevented from being minted to or sent to a parent NFT if the Budget threshold is met. 

2) Currently the code will do a calculation on functions like `burn_nft` and this will perform an arithmetic subtraction at the end of the function, but this should be added as a field in the `Value` type & implement a function from `Budget` to get the budget that has been consumed and budget that is left.

## Target
- [x] Fix minting/sending NFTs that exceed the threshold of `NestingBudget::get()` value.
- [x] Add fields names `budget_consumed` and budget_left` to track & through errors is an overflow is detected.
- [x] Add functions in `Budget` trait to get the 2 new fields.