### PR TITLE
Add MarketplaceHooks and MarketFee traits

### DIFF
--- a/pallets/rmrk-market/src/types.rs
+++ b/pallets/rmrk-market/src/types.rs
@@ -3,6 +3,7 @@
 // License: Apache 2.0 modified by RMRK, see LICENSE.md
 
 use frame_support::pallet_prelude::*;
+use sp_runtime::Permill;
 
 #[cfg(feature = "std")]
 use serde::{Deserialize, Serialize};
@@ -29,4 +30,33 @@ pub struct Offer<AccountId, Balance, BlockNumber> {
 	pub(super) amount: Balance,
 	/// After this block the offer can't be accepted
 	pub(super) expires: Option<BlockNumber>,
+}
+
+/// Trait to calculate Marketplace hooks that can be implemented downstream to enforce standard
+/// Marketplace fees and royalties.
+pub trait MarketplaceHooks<Balance, CollectionId, NftId> {
+	/// Market Fee.
+	type MarketFee;
+	/// Standard Marketplace fee set downstream. The default return value will be None.
+	fn calculate_market_fee(amount: Balance) -> Option<Balance>;
+	/// For Marketplaces that enforce royalties, a royalty fee is paid after a successful `buy()`.
+	/// Default return value is None.
+	fn calculate_royalty_fee(amount: Balance, royalty_fee: Permill) -> Option<Balance>;
+	/// Check to ensure the NFT can be listed or bought in the Marketplace. Default is true.
+	fn can_list_or_buy_in_marketplace(collection_id: &CollectionId, nft_id: &NftId) -> bool;
+}
+
+impl<Balance, CollectionId, NftId> MarketplaceHooks<Balance, CollectionId, NftId> for () {
+	type MarketFee = Permill;
+	fn calculate_market_fee(_amount: Balance) -> Option<Balance> {
+		None
+	}
+
+	fn calculate_royalty_fee(_amount: Balance, _royalty_fee: Permill) -> Option<Balance> {
+		None
+	}
+
+	fn can_list_or_buy_in_marketplace(_collection_id: &CollectionId, _nft_id: &NftId) -> bool {
+		true
+	}
 }


### PR DESCRIPTION
## Description
Currently the Market pallet has no way to check if the type of NFT can be sold (i.e. Stakepool v2 NFTs vs PhalaWorld Shell NFTs). To resolve this, there are an introduction to 2 new traits called `MarketplaceHooks` and `MarketFee` which will hold the standard market fee percentage constant in the `MarketFee` trait and the `MarketplaceHooks` will implement 3 functions called `calculate_market_fee(amount)` `calculate_royalty_fee(amount, royalty_fee)` and `can_list_or_buy_in_market(collections_id, nft_id)` that will help prevent NFTs from being listed that are not eligible for the marketplace.

## Targets
- [x] upgrade to `polkadot-v0.9.38`
- [x] add new traits `MarketFee` and `MarketplaceHooks`
- [ ] implement `Default` for the traits in runtime
- [ ] add new unit tests
- [ ] run integration tests
- [ ] calculate new weights if needed 